### PR TITLE
feat: Add the ability to proxy the requests to their respective sink

### DIFF
--- a/aiocloudweather/__main__.py
+++ b/aiocloudweather/__main__.py
@@ -28,9 +28,8 @@ async def my_handler(station: WeatherStation) -> None:
         if value is None:
             continue
 
-        print(f"{sensor.name}: {value.metric} ({value.metric_unit})")
-        print(f"{sensor.name}: {value.imperial} ({value.imperial_unit})")
-        print()
+        # print(f"{sensor.name}: {value.metric} ({value.metric_unit})")
+        # print(f"{sensor.name}: {value.imperial} ({value.imperial_unit})")
 
     # print(f"{str(station)}")
 
@@ -49,7 +48,7 @@ def main() -> None:
         sys.exit(1)
 
     print(f"Firing up webserver to listen on port {sys.argv[1]}")
-    cloudweather_server = CloudWeatherListener(port=sys.argv[1])
+    cloudweather_server = CloudWeatherListener(port=sys.argv[1], proxy_enabled=True)
 
     cloudweather_server.new_dataset_cb.append(my_handler)
     try:

--- a/aiocloudweather/proxy.py
+++ b/aiocloudweather/proxy.py
@@ -1,0 +1,42 @@
+"""Proxy for forwarding data to the CloudWeather APIs."""
+
+from enum import Enum
+from aiohttp import web
+from dns_client.adapters.requests import DNSClientSession
+import random
+from urllib.parse import quote
+
+import requests
+
+
+class DataSink(Enum):
+    """Data sinks for the CloudWeather API."""
+
+    WUNDERGROUND = "wunderground"
+    WEATHERCLOUD = "weathercloud"
+
+
+class CloudWeatherProxy:
+    """Proxy for forwarding data to the CloudWeather API."""
+
+    def __init__(self, dns_servers: list[str]):
+        self.session = DNSClientSession(host=random.choice(dns_servers))
+
+    async def forward_wunderground(self, request: web.Request) -> requests.Response:
+        """Forward Wunderground data to the API."""
+        query_string = quote(request.query_string).replace("%20", "+")
+        url = f"https://rtupdate.wunderground.com/weatherstation/updateweatherstation.php?{query_string}"
+        return self.session.get(url)
+
+    async def forward_weathercloud(self, request: web.Request) -> web.Response:
+        """Forward WeatherCloud data to the API."""
+        new_path = request.path[request.path.index("/v01/set") :]
+        url = f"https://api.weathercloud.net{new_path}"
+        return self.session.get(url)
+
+    async def forward(self, sink: DataSink, request: web.Request) -> requests.Response:
+        """Forward data to the CloudWeather API."""
+        if sink == DataSink.WUNDERGROUND:
+            return await self.forward_wunderground(request)
+        if sink == DataSink.WEATHERCLOUD:
+            return await self.forward_weathercloud(request)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=["tests.*", "tests"]),
     package_data={"aiocoudweather": ["py.typed"]},
     python_requires=">=3.12",
-    install_requires=["aiohttp>3"],
+    install_requires=["aiohttp>3", "requests>2", "dns-client>0.2"],
     entry_points={
         "console_scripts": ["cloudweather-testserver = aiocloudweather.__main__:main"]
     },


### PR DESCRIPTION
Adds the feature to pass through intercepted calls to Weather Undergroud and Weathercloud.net. In both cases the connection is also upgraded to HTTPS.

The DNS servers used to resolve the respective domains can be configured, as the local DNS server might serve proxy itself. It defaults to Quad9 if no other DNS server is provided. If more than one address is provided a random one from the list is chosen.

Closes: #1 